### PR TITLE
Added setting to use any of 4 screen anchors

### DIFF
--- a/addons/input-overlay/input-overlay-config.gd
+++ b/addons/input-overlay/input-overlay-config.gd
@@ -1,6 +1,18 @@
 extends Resource
 
+#
+# T/B | L/R | Enum
+#  0  |  0  | TOP_LEFT
+#  0  |  1  | TOP_RIGHT
+#  1  |  0  | BOTTOM_LEFT
+#  1  |  1  | BOTTOM_RIGHT
+#
+enum Anchors { TOP_LEFT, TOP_RIGHT, BOTTOM_LEFT, BOTTOM_RIGHT }
+
 @export_category("Layout")
-@export var margin_left = 32
+@export var margin_top = 32
+@export var margin_right = 32
 @export var margin_bottom = 32
+@export var margin_left = 32
 @export_range(0, 2) var scale: float = 1.0
+@export var anchor: Anchors = 2

--- a/addons/input-overlay/input-overlay-config.gd
+++ b/addons/input-overlay/input-overlay-config.gd
@@ -10,9 +10,7 @@ extends Resource
 enum Anchors { TOP_LEFT, TOP_RIGHT, BOTTOM_LEFT, BOTTOM_RIGHT }
 
 @export_category("Layout")
-@export var margin_top = 32
-@export var margin_right = 32
-@export var margin_bottom = 32
-@export var margin_left = 32
+@export var horizontal_margin = 32
+@export var vertical_margin = 32
 @export_range(0, 2) var scale: float = 1.0
 @export var anchor: Anchors = 2

--- a/addons/input-overlay/input-overlay-config.tres
+++ b/addons/input-overlay/input-overlay-config.tres
@@ -4,6 +4,9 @@
 
 [resource]
 script = ExtResource("1_07s87")
-margin_left = 32
+margin_top = 32
+margin_right = 32
 margin_bottom = 32
+margin_left = 32
 scale = 0.5
+anchor = 2

--- a/addons/input-overlay/input-overlay-config.tres
+++ b/addons/input-overlay/input-overlay-config.tres
@@ -4,9 +4,7 @@
 
 [resource]
 script = ExtResource("1_07s87")
-margin_top = 32
-margin_right = 32
-margin_bottom = 32
-margin_left = 32
+horizontal_margin = 32
+vertical_margin = 32
 scale = 0.5
 anchor = 2

--- a/addons/input-overlay/input-overlay.gd
+++ b/addons/input-overlay/input-overlay.gd
@@ -17,20 +17,37 @@ func _enter_tree():
 	main_screen.resized.connect(update_panel)
 	update_panel()
 
+
 func update_panel():
 	scale_widget()
 	position_widget()
 
+
 func position_widget():
-	var rect: Rect2 = main_screen.get_global_rect()
-	panel.position.x = rect.position.x
-	panel.position.y = rect.position.y + rect.size.y - panel.get_rect().size.y
-	panel.position.x += conf.margin_left
-	panel.position.y -= conf.margin_bottom
+	var rect = main_screen.get_global_rect()
+	var x = 0
+	var y = 0
+	panel.position = rect.position
+
+	if conf.anchor & 1: # Right
+		x += rect.size.x - panel.get_rect().size.x - conf.margin_right
+	else: # Left
+		x += conf.margin_left
+
+	if conf.anchor >> 1: # Bottom
+		y += rect.size.y - panel.get_rect().size.y - conf.margin_bottom
+	else: # Top
+		var toolbar_height = 32
+		y += conf.margin_top + toolbar_height
+
+	panel.position.x += x
+	panel.position.y += y
+
 
 func scale_widget():
 	var panel_scale = Vector2(conf.scale, conf.scale)
 	panel.scale = panel_scale
+
 
 func on_main_screen_changed(scrn):
 	if scrn == "3D" or scrn == "2D":

--- a/addons/input-overlay/input-overlay.gd
+++ b/addons/input-overlay/input-overlay.gd
@@ -30,15 +30,15 @@ func position_widget():
 	panel.position = rect.position
 
 	if conf.anchor & 1: # Right
-		x += rect.size.x - panel.get_rect().size.x - conf.margin_right
+		x += rect.size.x - panel.get_rect().size.x - conf.horizontal_margin
 	else: # Left
-		x += conf.margin_left
+		x += conf.horizontal_margin
 
 	if conf.anchor >> 1: # Bottom
-		y += rect.size.y - panel.get_rect().size.y - conf.margin_bottom
+		y += rect.size.y - panel.get_rect().size.y - conf.vertical_margin
 	else: # Top
 		var toolbar_height = 32
-		y += conf.margin_top + toolbar_height
+		y += conf.vertical_margin + toolbar_height
 
 	panel.position.x += x
 	panel.position.y += y


### PR DESCRIPTION
# More screen anchors

Just had to rename the margin variables and create a new enum with all possible anchors. I've used bit logic to reduce the amount of condition checks on the position calculations.

![image](https://github.com/crystal-bit/input-overlay/assets/11667069/d9d49d1a-5fef-4bf6-a87d-cd086f9069f1)

Closes #5 